### PR TITLE
updated xbldfull-VC8 to consider __Debug NO

### DIFF
--- a/xHarbourBuilder/xHarbour-Builder/xbldfull-VC8.bat
+++ b/xHarbourBuilder/xHarbour-Builder/xbldfull-VC8.bat
@@ -132,6 +132,7 @@ IF "%VC8_DEBUG%"=="YES"        SET _XB_Exe=%_XB_Debug%
 IF "%VC8_DEBUG%"=="NO"         SET _XB_Exe=%_XB_NonDebug%
 IF "%VC8_DEBUG%"=="YES"        SET _BUILD_DEBUG=YES
 IF "%VC8_DEBUG%"=="NO"         SET _BUILD_DEBUG=NO
+IF "%VC8_DEBUG%"=="NO"         SET _XB_Debug=%_XB_NonDebug%
 
 IF "%VC8_XBUILDW_AS%"=="DLL"   SET _BUILD_XBUILDW_AS=DLL
 IF "%VC8_XBUILDW_AS%"=="EXE"   SET _BUILD_XBUILDW_AS=EXE

--- a/xHarbourBuilder/xHarbour-Builder/xbldfull2.bat
+++ b/xHarbourBuilder/xHarbour-Builder/xbldfull2.bat
@@ -326,10 +326,10 @@ REM --> ZipArchive & ZLib & HBZlib
         IF "%_BUILD_HBZLIB%"=="NO" GOTO No_HBZlib
 
            CD "\xharbour\xHarbourBuilder\ZipArchive"
-           \xHB\bin\xBuild.exe ZipArchive.lib.xbp -NoXbp -Debug %1
+           \xHB\bin\xBuild.exe ZipArchive.lib.xbp %_XB_Debug% %1
 
            CD "\xharbour\xHarbourBuilder\ZipArchive\ZLib"
-           \xHB\bin\xBuild.exe ZLib.lib.xbp -NoXbp -Debug %1
+           \xHB\bin\xBuild.exe ZLib.lib.xbp %_XB_Debug% %1
 
            CD "\xharbour\xHarbourBuilder\xHarbour-HBZLib\%_XB_Compiler%"
            \xHB\bin\xBuild.exe xHBzip.lib.xbp %_XB_Debug% %1
@@ -394,7 +394,7 @@ REM --> ApolloRDD
 REM --> xHBComm
         IF "%_BUILD_XHBCOMM%"=="NO" GOTO No_xHBComm
             CD "\xharbour\xHarbourBuilder\xHarbour-xHBComm\Comm"
-            \xHB\bin\xBuild.exe Comm.lib.xbp -NoXbp -Debug %1
+            \xHB\bin\xBuild.exe Comm.lib.xbp %_XB_Debug% %1
 
             CD "\xharbour\xHarbourBuilder\xHarbour-xHBComm\xHBCommDll"
             IF     EXIST "%_XHB_DLL%\xHBCommDll.lib"     DEL "%_XHB_DLL%\xHBCommDll.lib" /Q


### PR DESCRIPTION
Possibility to compile xHarbour Builder sources non-debug when compiled for VC.
Just set the environment variable:
set VC8_DEBUG=NO