### PR TITLE
new crc algorithms and bldfull-VC8 to consider __Debug NO

### DIFF
--- a/source/rtl/hbcrc32.c
+++ b/source/rtl/hbcrc32.c
@@ -87,6 +87,8 @@ HB_FUNC( HB_CRC32 )
 #define		CRC_START_KERMIT	0x0000
 #define		CRC_START_CCITT_FFFF	0xFFFF
 #define		CRC_POLY_CCITT		0x1021
+#define		CRC_START_MODBUS	0xFFFF
+#define		CRC_POLY_16		0xA001
 
 static bool		crc_tab_init		= false;
 static uint16_t		crc_tab[256];
@@ -94,8 +96,8 @@ static uint16_t		crc_tab[256];
 static bool             crc_tabccitt_init       = false;
 static uint16_t         crc_tabccitt[256];
 
-
-uint16_t		crc_kermit(        const unsigned char *input_str, size_t num_bytes       );
+static bool             crc_tab16_init          = false;
+static uint16_t         crc_tab16[256];
 
 static void init_crc_tab( void ) {
 
@@ -148,6 +150,33 @@ static void init_crcccitt_tab( void ) {
 	}
 
 	crc_tabccitt_init = true;
+
+}
+
+static void init_crc16_tab( void ) {
+
+	uint16_t i;
+	uint16_t j;
+	uint16_t crc;
+	uint16_t c;
+
+	for (i=0; i<256; i++) {
+
+		crc = 0;
+		c   = i;
+
+		for (j=0; j<8; j++) {
+
+			if ( (crc ^ c) & 0x0001 ) crc = ( crc >> 1 ) ^ CRC_POLY_16;
+			else                      crc =   crc >> 1;
+
+			c = c >> 1;
+		}
+
+		crc_tab16[i] = crc;
+	}
+
+	crc_tab16_init = true;
 
 }
 
@@ -219,9 +248,36 @@ if ( ptr != NULL ) for (a=0; a<num_bytes; a++) {
 }
 
 return crc;
+}
 
-static uint16_t crc_ccitt_ffff( const unsigned char *input_str, size_t num_bytes ) 
-{
+uint16_t crc_modbus( const unsigned char *input_str, size_t num_bytes ) {
+
+	uint16_t crc;
+	uint16_t tmp;
+	uint16_t short_c;
+	const unsigned char *ptr;
+	size_t a;
+
+	if ( ! crc_tab16_init ) init_crc16_tab();
+
+	crc = CRC_START_MODBUS;
+	ptr = input_str;
+
+	if ( ptr != NULL ) for (a=0; a<num_bytes; a++) {
+
+		short_c = 0x00ff & (uint16_t) *ptr;
+		tmp     =  crc       ^ short_c;
+		crc     = (crc >> 8) ^ crc_tab16[ tmp & 0xff ];
+
+		ptr++;
+	}
+
+	return crc;
+
+}
+
+
+static uint16_t crc_ccitt_ffff( const unsigned char *input_str, size_t num_bytes ) {
 return crc_ccitt_generic( input_str, num_bytes, CRC_START_CCITT_FFFF );
 }
 
@@ -230,7 +286,7 @@ HB_FUNC( HB_CRC_KERMIT )
    hb_retnl( crc_kermit( ( unsigned char *  ) hb_parc( 1 ), hb_parclen( 1 ) ) );
 }
 
-HB_FUNC( HB_CRC_MCRF4XX ) // cText --> nTextCRC - codigo fonte obtido em https://gist.github.com/aurelj/270bb8af82f65fa645c1
+HB_FUNC( HB_CRC_MCRF4XX )
 {
    hb_retnl( crc_mcrf4xx( ( unsigned char *  ) hb_parc( 1 ), hb_parclen( 1 ) ) );
 }
@@ -241,11 +297,8 @@ HB_FUNC( C_EMTCRC_CCITT_FFFF )
 
 }
 
+HB_FUNC( C_EMTCRC_CRC_MODBUS )
+{
+   hb_retnl( crc_modbus( ( unsigned char *  ) hb_parc( 1 ), hb_parclen( 1 ) ) );
+}
 
-/*
-#TODO:
-
-C_EMTCRC_CCITT_FFFF
-C_EMTCRC_CRC_16
-C_EMTCRC_CRC_MODBUS
-*/

--- a/source/rtl/hbcrc32.c
+++ b/source/rtl/hbcrc32.c
@@ -84,50 +84,50 @@ HB_FUNC( HB_CRC32 )
 }
 
 #define		CRC_POLY_KERMIT		0x8408
-#define		CRC_START_KERMIT	0x0000
+#define		CRC_START_KERMIT	   0x0000
 #define		CRC_START_CCITT_FFFF	0xFFFF
-#define		CRC_POLY_CCITT		0x1021
-#define		CRC_START_MODBUS	0xFFFF
-#define		CRC_POLY_16		0xA001
+#define		CRC_POLY_CCITT		   0x1021
+#define		CRC_START_MODBUS	   0xFFFF
+#define		CRC_POLY_16	      	0xA001
 
-static bool		crc_tab_init		= false;
-static uint16_t		crc_tab[256];
+static bool crc_tab_init		= false;
+static bool crc_tabccitt_init = false;
+static bool crc_tab16_init    = false;
 
-static bool             crc_tabccitt_init       = false;
-static uint16_t         crc_tabccitt[256];
+static uint16_t crc_tab[256];
+static uint16_t crc_tabccitt[256];
+static uint16_t crc_tab16[256];
 
-static bool             crc_tab16_init          = false;
-static uint16_t         crc_tab16[256];
-
-static void init_crc_tab( void ) {
+static void init_crc_tab( void ) 
+{
 
    uint16_t i;
    uint16_t j;
    uint16_t crc;
    uint16_t c;
 
-   for (i=0; i<256; i++) {
+   for (i=0; i<256; i++) 
+   {
+      crc = 0;
+      c   = i;
 
-   crc = 0;
-   c   = i;
+      for (j=0; j<8; j++) {
 
-   for (j=0; j<8; j++) {
+         if ( (crc ^ c) & 0x0001 ) crc = ( crc >> 1 ) ^ CRC_POLY_KERMIT;
+         else                      crc =   crc >> 1;
 
-      if ( (crc ^ c) & 0x0001 ) crc = ( crc >> 1 ) ^ CRC_POLY_KERMIT;
-      else                      crc =   crc >> 1;
+         c = c >> 1;
+      }
 
-      c = c >> 1;
-   }
-
-   crc_tab[i] = crc;
+      crc_tab[i] = crc;
    }
 
    crc_tab_init = true;
 
 }
 
-static void init_crcccitt_tab( void ) {
-
+static void init_crcccitt_tab( void ) 
+{
 	uint16_t i;
 	uint16_t j;
 	uint16_t crc;
@@ -153,36 +153,34 @@ static void init_crcccitt_tab( void ) {
 
 }
 
-static void init_crc16_tab( void ) {
-
+static void init_crc16_tab( void ) 
+{
 	uint16_t i;
 	uint16_t j;
 	uint16_t crc;
 	uint16_t c;
 
-	for (i=0; i<256; i++) {
-
+	for (i=0; i<256; i++) 
+   {
 		crc = 0;
 		c   = i;
 
-		for (j=0; j<8; j++) {
+		for (j=0; j<8; j++) 
+      {
 
 			if ( (crc ^ c) & 0x0001 ) crc = ( crc >> 1 ) ^ CRC_POLY_16;
 			else                      crc =   crc >> 1;
 
 			c = c >> 1;
 		}
-
 		crc_tab16[i] = crc;
 	}
-
 	crc_tab16_init = true;
-
 }
 
 
-static uint16_t crc_kermit( const unsigned char *input_str, size_t num_bytes ) {
-
+static uint16_t crc_kermit( const unsigned char *input_str, size_t num_bytes ) 
+{
    uint16_t crc;
    uint16_t low_byte;
    uint16_t high_byte;
@@ -194,9 +192,9 @@ static uint16_t crc_kermit( const unsigned char *input_str, size_t num_bytes ) {
    crc = CRC_START_KERMIT;
    ptr = input_str;
 
-   if ( ptr != NULL ) for (a=0; a<num_bytes; a++) {
-
-   crc = (crc >> 8) ^ crc_tab[ (crc ^ (uint16_t) *ptr++) & 0x00FF ];
+   if ( ptr != NULL ) for (a=0; a<num_bytes; a++) 
+   {
+      crc = (crc >> 8) ^ crc_tab[ (crc ^ (uint16_t) *ptr++) & 0x00FF ];
    }
 
    low_byte  = (crc & 0xff00) >> 8;
@@ -207,7 +205,7 @@ static uint16_t crc_kermit( const unsigned char *input_str, size_t num_bytes ) {
 
 }
 
-static uint16_t crc_mcrf4xx(uint8_t *data, size_t len)
+static uint16_t crc_mcrf4xx(uint8_t *data, size_t len) 
 {
    uint16_t crc;
 
@@ -216,7 +214,8 @@ static uint16_t crc_mcrf4xx(uint8_t *data, size_t len)
    if (!data || len < 0)
         return crc;
 
-    while (len--) {
+    while (len--) 
+    {
         crc ^= *data++;
         for (int i=0; i<8; i++) {
             if (crc & 1)  crc = (crc >> 1) ^ 0x8408;
@@ -226,32 +225,33 @@ static uint16_t crc_mcrf4xx(uint8_t *data, size_t len)
     return crc;   
 }
 
-static uint16_t crc_ccitt_generic( const unsigned char *input_str, size_t num_bytes, uint16_t start_value ) {
-uint16_t crc;
-uint16_t tmp;
-uint16_t short_c;
-const unsigned char *ptr;
-size_t a;
+static uint16_t crc_ccitt_generic( const unsigned char *input_str, size_t num_bytes, uint16_t start_value ) 
+{
+   uint16_t crc;
+   uint16_t tmp;
+   uint16_t short_c;
+   const unsigned char *ptr;
+   size_t a;
 
-if ( ! crc_tabccitt_init ) init_crcccitt_tab();
+   if ( ! crc_tabccitt_init ) init_crcccitt_tab();
 
-crc = start_value;
-ptr = input_str;
+   crc = start_value;
+   ptr = input_str;
 
-if ( ptr != NULL ) for (a=0; a<num_bytes; a++) {
+   if ( ptr != NULL ) for (a=0; a<num_bytes; a++) 
+   {
+      short_c = 0x00ff & (unsigned short) *ptr;
+      tmp     = (crc >> 8) ^ short_c;
+      crc     = (crc << 8) ^ crc_tabccitt[tmp];
 
-   short_c = 0x00ff & (unsigned short) *ptr;
-   tmp     = (crc >> 8) ^ short_c;
-   crc     = (crc << 8) ^ crc_tabccitt[tmp];
+      ptr++;
+   }
 
-   ptr++;
+   return crc;
 }
 
-return crc;
-}
-
-uint16_t crc_modbus( const unsigned char *input_str, size_t num_bytes ) {
-
+static uint16_t crc_modbus( const unsigned char *input_str, size_t num_bytes ) 
+{
 	uint16_t crc;
 	uint16_t tmp;
 	uint16_t short_c;
@@ -263,7 +263,8 @@ uint16_t crc_modbus( const unsigned char *input_str, size_t num_bytes ) {
 	crc = CRC_START_MODBUS;
 	ptr = input_str;
 
-	if ( ptr != NULL ) for (a=0; a<num_bytes; a++) {
+	if ( ptr != NULL ) for (a=0; a<num_bytes; a++) 
+   {
 
 		short_c = 0x00ff & (uint16_t) *ptr;
 		tmp     =  crc       ^ short_c;
@@ -273,32 +274,62 @@ uint16_t crc_modbus( const unsigned char *input_str, size_t num_bytes ) {
 	}
 
 	return crc;
-
 }
 
-
-static uint16_t crc_ccitt_ffff( const unsigned char *input_str, size_t num_bytes ) {
-return crc_ccitt_generic( input_str, num_bytes, CRC_START_CCITT_FFFF );
+static uint16_t crc_ccitt_ffff( const unsigned char *input_str, size_t num_bytes ) 
+{
+   return crc_ccitt_generic( input_str, num_bytes, CRC_START_CCITT_FFFF );
 }
 
 HB_FUNC( HB_CRC_KERMIT )
 {
+   PHB_ITEM pString  = hb_param( 1, HB_IT_STRING );
+
+   if( pString == NULL )
+   {
+      hb_errRT_BASE_SubstR( EG_ARG, 3012, NULL, "Must be a string", 1, hb_param( 1, HB_IT_ANY ) );
+      return;
+   }
+
    hb_retnl( crc_kermit( ( unsigned char *  ) hb_parc( 1 ), hb_parclen( 1 ) ) );
 }
 
 HB_FUNC( HB_CRC_MCRF4XX )
 {
+   PHB_ITEM pString  = hb_param( 1, HB_IT_STRING );
+
+   if( pString == NULL )
+   {
+      hb_errRT_BASE_SubstR( EG_ARG, 3012, NULL, "Must be a string", 1, hb_param( 1, HB_IT_ANY ) );
+      return;
+   }
+
    hb_retnl( crc_mcrf4xx( ( unsigned char *  ) hb_parc( 1 ), hb_parclen( 1 ) ) );
 }
 
-HB_FUNC( C_EMTCRC_CCITT_FFFF )
+HB_FUNC( HB_CCITT_FFFF )
 {
-   hb_retnl( crc_ccitt_ffff( ( unsigned char *  ) hb_parc( 1 ), hb_parclen( 1 ) ) );
+   PHB_ITEM pString  = hb_param( 1, HB_IT_STRING );
 
+   if( pString == NULL )
+   {
+      hb_errRT_BASE_SubstR( EG_ARG, 3012, NULL, "Must be a string", 1, hb_param( 1, HB_IT_ANY ) );
+      return;
+   }
+
+   hb_retnl( crc_ccitt_ffff( ( unsigned char *  ) hb_parc( 1 ), hb_parclen( 1 ) ) );
 }
 
-HB_FUNC( C_EMTCRC_CRC_MODBUS )
+HB_FUNC( HB_CRC_MODBUS )
 {
+   PHB_ITEM pString  = hb_param( 1, HB_IT_STRING );
+
+   if( pString == NULL )
+   {
+      hb_errRT_BASE_SubstR( EG_ARG, 3012, NULL, "Must be a string", 1, hb_param( 1, HB_IT_ANY ) );
+      return;
+   }
+
    hb_retnl( crc_modbus( ( unsigned char *  ) hb_parc( 1 ), hb_parclen( 1 ) ) );
 }
 

--- a/source/rtl/hbcrc32.c
+++ b/source/rtl/hbcrc32.c
@@ -83,3 +83,169 @@ HB_FUNC( HB_CRC32 )
                       ( uInt ) hb_itemGetCLen( pString ) ) );
 }
 
+#define		CRC_POLY_KERMIT		0x8408
+#define		CRC_START_KERMIT	0x0000
+#define		CRC_START_CCITT_FFFF	0xFFFF
+#define		CRC_POLY_CCITT		0x1021
+
+static bool		crc_tab_init		= false;
+static uint16_t		crc_tab[256];
+
+static bool             crc_tabccitt_init       = false;
+static uint16_t         crc_tabccitt[256];
+
+
+uint16_t		crc_kermit(        const unsigned char *input_str, size_t num_bytes       );
+
+static void init_crc_tab( void ) {
+
+   uint16_t i;
+   uint16_t j;
+   uint16_t crc;
+   uint16_t c;
+
+   for (i=0; i<256; i++) {
+
+   crc = 0;
+   c   = i;
+
+   for (j=0; j<8; j++) {
+
+      if ( (crc ^ c) & 0x0001 ) crc = ( crc >> 1 ) ^ CRC_POLY_KERMIT;
+      else                      crc =   crc >> 1;
+
+      c = c >> 1;
+   }
+
+   crc_tab[i] = crc;
+   }
+
+   crc_tab_init = true;
+
+}
+
+static void init_crcccitt_tab( void ) {
+
+	uint16_t i;
+	uint16_t j;
+	uint16_t crc;
+	uint16_t c;
+
+	for (i=0; i<256; i++) {
+
+		crc = 0;
+		c   = i << 8;
+
+		for (j=0; j<8; j++) {
+
+			if ( (crc ^ c) & 0x8000 ) crc = ( crc << 1 ) ^ CRC_POLY_CCITT;
+			else                      crc =   crc << 1;
+
+			c = c << 1;
+		}
+
+		crc_tabccitt[i] = crc;
+	}
+
+	crc_tabccitt_init = true;
+
+}
+
+
+static uint16_t crc_kermit( const unsigned char *input_str, size_t num_bytes ) {
+
+   uint16_t crc;
+   uint16_t low_byte;
+   uint16_t high_byte;
+   const unsigned char *ptr;
+   size_t a;
+
+   if ( ! crc_tab_init ) init_crc_tab();
+
+   crc = CRC_START_KERMIT;
+   ptr = input_str;
+
+   if ( ptr != NULL ) for (a=0; a<num_bytes; a++) {
+
+   crc = (crc >> 8) ^ crc_tab[ (crc ^ (uint16_t) *ptr++) & 0x00FF ];
+   }
+
+   low_byte  = (crc & 0xff00) >> 8;
+   high_byte = (crc & 0x00ff) << 8;
+   crc       = low_byte | high_byte;
+
+   return crc;
+
+}
+
+static uint16_t crc_mcrf4xx(uint8_t *data, size_t len)
+{
+   uint16_t crc;
+
+   crc = CRC_START_CCITT_FFFF;
+
+   if (!data || len < 0)
+        return crc;
+
+    while (len--) {
+        crc ^= *data++;
+        for (int i=0; i<8; i++) {
+            if (crc & 1)  crc = (crc >> 1) ^ 0x8408;
+            else          crc = (crc >> 1);
+        }
+    }
+    return crc;   
+}
+
+static uint16_t crc_ccitt_generic( const unsigned char *input_str, size_t num_bytes, uint16_t start_value ) {
+uint16_t crc;
+uint16_t tmp;
+uint16_t short_c;
+const unsigned char *ptr;
+size_t a;
+
+if ( ! crc_tabccitt_init ) init_crcccitt_tab();
+
+crc = start_value;
+ptr = input_str;
+
+if ( ptr != NULL ) for (a=0; a<num_bytes; a++) {
+
+   short_c = 0x00ff & (unsigned short) *ptr;
+   tmp     = (crc >> 8) ^ short_c;
+   crc     = (crc << 8) ^ crc_tabccitt[tmp];
+
+   ptr++;
+}
+
+return crc;
+
+static uint16_t crc_ccitt_ffff( const unsigned char *input_str, size_t num_bytes ) 
+{
+return crc_ccitt_generic( input_str, num_bytes, CRC_START_CCITT_FFFF );
+}
+
+HB_FUNC( HB_CRC_KERMIT )
+{
+   hb_retnl( crc_kermit( ( unsigned char *  ) hb_parc( 1 ), hb_parclen( 1 ) ) );
+}
+
+HB_FUNC( HB_CRC_MCRF4XX ) // cText --> nTextCRC - codigo fonte obtido em https://gist.github.com/aurelj/270bb8af82f65fa645c1
+{
+   hb_retnl( crc_mcrf4xx( ( unsigned char *  ) hb_parc( 1 ), hb_parclen( 1 ) ) );
+}
+
+HB_FUNC( C_EMTCRC_CCITT_FFFF )
+{
+   hb_retnl( crc_ccitt_ffff( ( unsigned char *  ) hb_parc( 1 ), hb_parclen( 1 ) ) );
+
+}
+
+
+/*
+#TODO:
+
+C_EMTCRC_CCITT_FFFF
+C_EMTCRC_CRC_16
+C_EMTCRC_CRC_MODBUS
+*/

--- a/tests/test_crc32.prg
+++ b/tests/test_crc32.prg
@@ -1,0 +1,39 @@
+PROCEDURE MAIN()
+    Local cText := "xHarbour"
+    Local nCrc
+
+    nCrc := HB_CRC32(cText)
+    ? "HB_CRC32 => " + FormatCrc(nCrc) + " Invert => "+ FormatCrc(nCrc, .t.)
+
+    nCrc := HB_CRC_KERMIT(cText)
+    ? "HB_CRC_KERMIT => " + FormatCrc(nCrc) + " Invert => "+ FormatCrc(nCrc, .t.)
+
+    nCrc := HB_CRC_MCRF4XX(cText)
+    ? "HB_CRC_MCRF4XX => " + FormatCrc(nCrc) + " Invert => "+ FormatCrc(nCrc, .t.)
+
+    nCrc := HB_CCITT_FFFF(cText)
+    ? "HB_CCITT_FFFF => " + FormatCrc(nCrc) + " Invert => "+ FormatCrc(nCrc, .t.)
+
+    nCrc := HB_CRC_MODBUS(cText)
+    ? "HB_CRC_MODBUS => " + FormatCrc(nCrc) + " Invert => "+ FormatCrc(nCrc, .t.)
+
+    RETURN
+
+Static Function FormatCrc(nCrc, lInvert)
+    Local cCrc := NumToHex(nCrc)
+    Local cCrc_Str
+    Local nI
+
+    lInvert = If(lInvert==nil, .f., lInvert)
+    cCrc := PadL(NumToHex(nCrc), 4, "0")
+
+    If lInvert
+        cCrc_Str := HexToStr(cCrc)
+        cCrc := ""
+        For nI := Len(cCrc_Str) to 1 Step -1
+            cCrc+=cCrc_Str[nI]
+        Next
+        cCrc := StrToHex(cCrc)
+    EndIf
+
+    Return cCrc

--- a/xHarbourBuilder/xHarbour-Builder/xbldfull-VC8.bat
+++ b/xHarbourBuilder/xHarbour-Builder/xbldfull-VC8.bat
@@ -132,6 +132,7 @@ IF "%VC8_DEBUG%"=="YES"        SET _XB_Exe=%_XB_Debug%
 IF "%VC8_DEBUG%"=="NO"         SET _XB_Exe=%_XB_NonDebug%
 IF "%VC8_DEBUG%"=="YES"        SET _BUILD_DEBUG=YES
 IF "%VC8_DEBUG%"=="NO"         SET _BUILD_DEBUG=NO
+IF "%VC8_DEBUG%"=="NO"         SET _XB_Debug=%_XB_NonDebug%
 
 IF "%VC8_XBUILDW_AS%"=="DLL"   SET _BUILD_XBUILDW_AS=DLL
 IF "%VC8_XBUILDW_AS%"=="EXE"   SET _BUILD_XBUILDW_AS=EXE

--- a/xHarbourBuilder/xHarbour-Builder/xbldfull2.bat
+++ b/xHarbourBuilder/xHarbour-Builder/xbldfull2.bat
@@ -326,10 +326,10 @@ REM --> ZipArchive & ZLib & HBZlib
         IF "%_BUILD_HBZLIB%"=="NO" GOTO No_HBZlib
 
            CD "\xharbour\xHarbourBuilder\ZipArchive"
-           \xHB\bin\xBuild.exe ZipArchive.lib.xbp -NoXbp -Debug %1
+           \xHB\bin\xBuild.exe ZipArchive.lib.xbp %_XB_Debug% %1
 
            CD "\xharbour\xHarbourBuilder\ZipArchive\ZLib"
-           \xHB\bin\xBuild.exe ZLib.lib.xbp -NoXbp -Debug %1
+           \xHB\bin\xBuild.exe ZLib.lib.xbp %_XB_Debug% %1
 
            CD "\xharbour\xHarbourBuilder\xHarbour-HBZLib\%_XB_Compiler%"
            \xHB\bin\xBuild.exe xHBzip.lib.xbp %_XB_Debug% %1
@@ -394,7 +394,7 @@ REM --> ApolloRDD
 REM --> xHBComm
         IF "%_BUILD_XHBCOMM%"=="NO" GOTO No_xHBComm
             CD "\xharbour\xHarbourBuilder\xHarbour-xHBComm\Comm"
-            \xHB\bin\xBuild.exe Comm.lib.xbp -NoXbp -Debug %1
+            \xHB\bin\xBuild.exe Comm.lib.xbp %_XB_Debug% %1
 
             CD "\xharbour\xHarbourBuilder\xHarbour-xHBComm\xHBCommDll"
             IF     EXIST "%_XHB_DLL%\xHBCommDll.lib"     DEL "%_XHB_DLL%\xHBCommDll.lib" /Q


### PR DESCRIPTION
Possibility to compile xHarbour Builder sources non-debug when compiled for VC.
Just set the environment variable:
set VC8_DEBUG=NO

new crc algorithms:
KERMIT
MC F4XX
CCITT FFFF
MODBUS

Usage example in:
tests\test_crc32.prg