### PR TITLE
Fixed compilation warning flags of hbzip library with BCC64

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,10 @@
    2002-12-01 23:12 UTC+0100 Foo Bar <foo.bar@foobar.org>
 */
 
+2023-11-07 16:28 UTC+0100 Enrico Maria Giordano <e.m.giordano@emagsoftware.it>
+  * winmake\makefile.bc
+    ! fixed compilation warning flags of hbzip library with BCC64
+
 2023-11-07 11:53 UTC+0100 Enrico Maria Giordano <e.m.giordano@emagsoftware.it>
   * winmake\common1.mak
     ! fixed compilation of curl contrib library

--- a/winmake/makefile.bc
+++ b/winmake/makefile.bc
@@ -18,15 +18,15 @@ CC        =bcc64
 LINKEXE   =ilink64
 LIBEXE    =tlib64
 IMPLIBEXE =MKEXP
+OPTFLAGS=-q -d -fpack-struct=8
 !else
 ACE_LIB   =$(ACE32_LIB)
 CC        =BCC32
 LINKEXE   =ILINK32
 LIBEXE    =TLIB
 IMPLIBEXE =IMPLIB
-!endif
-
 OPTFLAGS=-q -d -a8
+!endif
 
 !if ( ( ("$(HB_CG32)"=="1") || ("$(HB_DEBUG)"=="d") ) && !defined( HB_OS_WIN_64 ) )
 COMPILERLIBS=\
@@ -226,7 +226,7 @@ CC_CMD_HARBOUR =$(CC) -c -tWM -D__HB_COMPILER__ $(CC_COMP_DEFINES) $(CLIBFLAGS) 
 CCC_CMD        =$(CC_CMD)
 
 !if ("$(HB_ARCH)"=="64")
-CC_CMD_ZIP     =$(CC) -c $(CC_DEBUGFLAGS) -I"$(HBZIP_DIR)\include" -I"include" -R- $(OPTFLAGS) -X- -o$@ $**
+CC_CMD_ZIP     =$(CC) -c $(CC_DEBUGFLAGS) -I"$(HBZIP_DIR)\include" -I"include" $(OPTFLAGS) -Wno-user-defined-literals -Wno-unused-value -Wno-tautological-compare -Wno-int-to-void-pointer-cast -o$@ $**
 !else
 CC_CMD_ZIP     =$(CC) -c $(CC_DEBUGFLAGS) -I"$(HBZIP_DIR)\include" -I"include" -vi -R- -H- $(OPTFLAGS) -w- -X- -o$@ $**
 !endif


### PR DESCRIPTION
Fixed compilation warning flags of hbzip library with BCC64