### PR TITLE
Fixed hb_curl_xfree() to avoid error with null pointer

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,10 @@
    2002-12-01 23:12 UTC+0100 Foo Bar <foo.bar@foobar.org>
 */
 
+2023-11-19 11:20 UTC+0100 Enrico Maria Giordano <e.m.giordano@emagsoftware.it>
+  * contrib\hbcurl\hbcurl.c
+    ! Fixed hb_curl_xfree() to avoid error with null pointer
+
 2023-11-15 13:11 UTC+0100 Enrico Maria Giordano <e.m.giordano@emagsoftware.it>
   * make_bc.bat
     ! Change end of line character from LF to CRLF to fix the wrong execution of GOTO statements

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,15 +10,15 @@
 
 2023-11-19 11:20 UTC+0100 Enrico Maria Giordano <e.m.giordano@emagsoftware.it>
   * contrib\hbcurl\hbcurl.c
-    ! Fixed hb_curl_xfree() to avoid error with null pointer
+    ! fixed hb_curl_xfree() to avoid error with null pointer
 
 2023-11-15 13:11 UTC+0100 Enrico Maria Giordano <e.m.giordano@emagsoftware.it>
   * make_bc.bat
-    ! Change end of line character from LF to CRLF to fix the wrong execution of GOTO statements
+    ! change end of line character from LF to CRLF to fix the wrong execution of GOTO statements
 
 2023-11-10 17:23 UTC+0100 Enrico Maria Giordano <e.m.giordano@emagsoftware.it>
   * make_vc.bat
-    ! Change the name of the SUB_DIR: vc32 and vc64 instead of vc
+    ! change the name of the SUB_DIR: vc32 and vc64 instead of vc
 
 2023-11-08 19:22 UTC+0100 Enrico Maria Giordano <e.m.giordano@emagsoftware.it>
   * contrib\hbssl\pem.c

--- a/contrib/hbcurl/hbcurl.c
+++ b/contrib/hbcurl/hbcurl.c
@@ -206,7 +206,7 @@ static void * hb_curl_xgrab( size_t size )
 
 static void hb_curl_xfree( void * p )
 {
-   hb_xfree( p );
+   if ( p ) hb_xfree( p );
 }
 
 static void * hb_curl_xrealloc( void * p, size_t size )


### PR DESCRIPTION
Fixed hb_curl_xfree() to avoid error with null pointer