### PR TITLE
Set LIBEXT to .a and OBJEXT to .o for 64 bit

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,10 @@
    2002-12-01 23:12 UTC+0100 Foo Bar <foo.bar@foobar.org>
 */
 
+2024-01-20 11:25 UTC+0100 Enrico Maria Giordano <e.m.giordano@emagsoftware.it>
+  * make_bc.bat
+    ! set LIBEXT to .a and OBJEXT to .o for 64 bit
+
 2024-01-19 14:56 UTC+0100 Enrico Maria Giordano <e.m.giordano@emagsoftware.it>
   * winmake\makefile.vc
     ! added -wd4244 -wd4267 -wd4312 to CC_CMD_ZIP

--- a/make_bc.bat
+++ b/make_bc.bat
@@ -96,6 +96,8 @@ rem ============================================================================
 SET LIBEXT=%HB_DEBUG%.lib
 SET OBJEXT=%HB_DEBUG%.obj
 SET DIR_SEP=\
+IF "%HB_ARCH%"=="w64" SET LIBEXT=%HB_DEBUG%.a
+IF "%HB_ARCH%"=="w64" SET OBJEXT=%HB_DEBUG%.o
 SET LIBPREFIX=
 rem ============================================================================
 


### PR DESCRIPTION
Set LIBEXT to .a and OBJEXT to .o for 64 bit