### PR TITLE
Set HB_ARCH to w64 if ml64.exe does exist in MSC bin directory

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,10 @@
    2002-12-01 23:12 UTC+0100 Foo Bar <foo.bar@foobar.org>
 */
 
+2024-01-20 14:10 UTC+0100 Enrico Maria Giordano <e.m.giordano@emagsoftware.it>
+  * winmake/find_vc.bat
+    ! set HB_ARCH to w64 if ml64.exe does exist in MSC bin directory
+
 2024-01-20 11:25 UTC+0100 Enrico Maria Giordano <e.m.giordano@emagsoftware.it>
   * make_bc.bat
     ! set LIBEXT to .a and OBJEXT to .o for 64 bit

--- a/winmake/find_vc.bat
+++ b/winmake/find_vc.bat
@@ -117,6 +117,7 @@ GOTO FIND_EXIT_99
    REM We arrived here ONLY if %CC%.exe exists in %CC_DIR%\bin and not in PATH.
     
    REM MSC Specific!
+   IF EXIST "%CC_DIR%\bin\ml64.exe" SET "HB_ARCH=w64"
    IF "%HB_ARCH%" == "" (
       IF "%is_x64_arch%" == "true" (
          ECHO Setting HB_ARCH to w64 because is_x64_arch is true.


### PR DESCRIPTION
Set HB_ARCH to w64 if ml64.exe does exist in MSC bin directory