### PR TITLE
Cherry-pick harbour commit https://github.com/harbour/core/issues/388

### DIFF
--- a/include/hbapifs.h
+++ b/include/hbapifs.h
@@ -231,13 +231,6 @@ extern HB_EXPORT BOOL       hb_fsCloseProcess( HB_FHANDLE fhProc, BOOL bGentle )
 #  define HB_USE_SHARELOCKS
 #  define HB_SHARELOCK_POS          0x7fffffffUL
 #  define HB_SHARELOCK_SIZE         0x1UL
-#  if defined( HB_USE_BSDLOCKS_OFF )
-#     undef HB_USE_BSDLOCKS
-#  elif ( defined( HB_OS_LINUX ) /*|| defined( HB_OS_BSD )*/ ) && \
-        !defined( __WATCOMC__ ) && !defined( HB_USE_BSDLOCKS )
-      /* At least FreeBSD 6.2 and Mac OS X deadlock using BSDLOCKS so I disabled them -- Ph. */
-#     define HB_USE_BSDLOCKS
-#  endif
 #endif
 
 #define HB_MAX_DRIVE_LENGTH   10

--- a/source/rtl/filebuf.c
+++ b/source/rtl/filebuf.c
@@ -442,7 +442,7 @@ static PHB_FILE s_fileExtOpen( const char * pFilename, const char * pDefExt,
             }
             if( pFile->uiLocks == 0 )
             {
-#if ! defined( HB_USE_SHARELOCKS ) || defined( HB_USE_BSDLOCKS )
+#if ! defined( HB_USE_SHARELOCKS )
                if( pFile->hFileRO != FS_ERROR )
                {
                   hb_fsClose( pFile->hFileRO );
@@ -453,7 +453,7 @@ static PHB_FILE s_fileExtOpen( const char * pFilename, const char * pDefExt,
                {
                   hb_fsClose( hFile );
                   hFile = FS_ERROR;
-#if defined( HB_USE_SHARELOCKS ) && ! defined( HB_USE_BSDLOCKS )
+#if defined( HB_USE_SHARELOCKS )
                   /* TOFIX: possible race condition */
                   hb_fsLockLarge( hFile, HB_SHARELOCK_POS, HB_SHARELOCK_SIZE,
                                   FL_LOCK | FLX_SHARED );

--- a/source/rtl/filesys.c
+++ b/source/rtl/filesys.c
@@ -234,7 +234,7 @@ extern int fdatasync( int fildes );
       #define INVALID_FILE_ATTRIBUTES  ( ( DWORD ) -1 )
    #endif
 #endif
-#if defined( HB_USE_SHARELOCKS ) && defined( HB_USE_BSDLOCKS )
+#if defined( HB_USE_SHARELOCKS )
    #include <sys/file.h>
 #endif
 
@@ -4208,18 +4208,6 @@ HB_FHANDLE hb_fsExtOpen( const char * pFilename, const char * pDefExt,
 #if defined( HB_USE_SHARELOCKS )
    if( hFile != FS_ERROR && uiExFlags & FXO_SHARELOCK )
    {
-#if defined( HB_USE_BSDLOCKS )
-      int iLock;
-      if( ( uiFlags & ( FO_READ | FO_WRITE | FO_READWRITE ) ) == FO_READ ||
-          ( uiFlags & ( FO_DENYREAD | FO_DENYWRITE | FO_EXCLUSIVE ) ) == 0 )
-         iLock = LOCK_SH | LOCK_NB;
-      else
-         iLock = LOCK_EX | LOCK_NB;
-      hb_vmUnlock();
-      iLock = flock( hFile, iLock );
-      hb_vmLock();
-      if( iLock != 0 )
-#else
       USHORT uiLock;
       if( ( uiFlags & ( FO_READ | FO_WRITE | FO_READWRITE ) ) == FO_READ ||
           ( uiFlags & ( FO_DENYREAD | FO_DENYWRITE | FO_EXCLUSIVE ) ) == 0 )
@@ -4228,7 +4216,6 @@ HB_FHANDLE hb_fsExtOpen( const char * pFilename, const char * pDefExt,
          uiLock = FL_LOCK | FLX_EXCLUSIVE;
 
       if( ! hb_fsLockLarge( hFile, HB_SHARELOCK_POS, HB_SHARELOCK_SIZE, uiLock ) )
-#endif
       {
          hb_fsClose( hFile );
          hFile = FS_ERROR;


### PR DESCRIPTION
 * include/hbapifs.h * src/rdd/wacore.c * src/rtl/filebuf.c
 + Fixed locking mechanism for SMB related networks and Linux kernel >= 5.5
 - Removed old HB_USE_BSDLOCKS implementation, now broken on Linux too Closes: https://github.com/harbour/core/issues/388 issue: #338

PR: https://github.com/harbour/core/pull/389